### PR TITLE
Adds backwards compatibility + an official LateMixin method

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -68,7 +68,7 @@ import org.spongepowered.asm.util.perf.Profiler.Section;
 /**
  * Heart of the Mixin pipeline 
  */
-class MixinProcessor implements IMixinProcessor {
+public class MixinProcessor implements IMixinProcessor {
 
     /**
      * Phase during which an error occurred, delegates to functionality in
@@ -595,6 +595,17 @@ class MixinProcessor implements IMixinProcessor {
         this.pendingConfigs.clear();
         
         return totalMixins;
+    }
+    
+    /**
+     * @deprecated Compatibility with common brittle Reflection-based usages pre-0.8.
+     * @param environment Environment
+     * @return Total number of Mixins initialized
+     */
+    @Deprecated
+    private int prepareConfigs(MixinEnvironment environment) {
+        MixinProcessor.logger.warn("MixinTransformer::prepareConfigs(MixinEnvironment) is deprecated!");
+        return prepareConfigs(environment, this.extensions);
     }
 
     private void handleMixinPrepareError(MixinConfig config, InvalidMixinException ex, MixinEnvironment environment) throws MixinPrepareError {

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinProcessor.java
@@ -173,7 +173,7 @@ public class MixinProcessor implements IMixinProcessor {
     /**
      * Processor extensions
      */
-    private final Extensions extensions;
+    public final Extensions extensions;
     
     /**
      * Hot-Swap agent
@@ -501,7 +501,7 @@ public class MixinProcessor implements IMixinProcessor {
      * 
      * @param environment Environment to query
      */
-    private void selectConfigs(MixinEnvironment environment) {
+    public void selectConfigs(MixinEnvironment environment) {
         for (Iterator<Config> iter = Mixins.getConfigs().iterator(); iter.hasNext();) {
             Config handle = iter.next();
             try {
@@ -521,12 +521,12 @@ public class MixinProcessor implements IMixinProcessor {
     }
 
     /**
-     * Prepare mixin configs
+     * Prepares pending mixin configs
      * 
      * @param environment Environment
      * @return total number of mixins initialised
      */
-    private int prepareConfigs(MixinEnvironment environment, Extensions extensions) {
+    protected int prepareConfigs(MixinEnvironment environment, Extensions extensions) {
         int totalMixins = 0;
         
         final IHotSwap hotSwapper = this.hotSwapper;
@@ -598,13 +598,14 @@ public class MixinProcessor implements IMixinProcessor {
     }
     
     /**
-     * @deprecated Compatibility with common brittle Reflection-based usages pre-0.8.
+     * @deprecated Added for compatibility with unfortunately-common brittle Reflection-based usages pre-0.8.
+     * @see MixinProcessor#prepareConfigs(org.spongepowered.asm.mixin.MixinEnvironment, org.spongepowered.asm.mixin.transformer.ext.Extensions)
      * @param environment Environment
      * @return Total number of Mixins initialized
      */
     @Deprecated
     private int prepareConfigs(MixinEnvironment environment) {
-        MixinProcessor.logger.warn("MixinTransformer::prepareConfigs(MixinEnvironment) is deprecated!");
+        MixinProcessor.logger.warn("MixinProcessor::prepareConfigs(MixinEnvironment) is deprecated!");
         return prepareConfigs(environment, this.extensions);
     }
 

--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinTransformer.java
@@ -43,7 +43,7 @@ import org.spongepowered.asm.util.asm.ASM;
 /**
  * Transformer which manages the mixin configuration and application process
  */
-final class MixinTransformer extends TreeTransformer implements IMixinTransformer {
+public final class MixinTransformer extends TreeTransformer implements IMixinTransformer {
     
     /**
      * Impl of mixin transformer factory


### PR DESCRIPTION
Fixes CleanroomMC/MixinBooter#34 permanently. Also adds a way to run a second pass for new Mixin configs at any point in the Forge lifecycle to the FML-specific `Proxy` that already exists.

Also makes a class public to match its preexisting public visibility in `Proxy`.