### PR TITLE
Fix compatibility with older ASM (5.0.3)

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/struct/MemberRef.java
+++ b/src/main/java/org/spongepowered/asm/mixin/struct/MemberRef.java
@@ -266,7 +266,7 @@ public abstract class MemberRef {
         }
 
         public void setHandle(int tag, String owner, String name, String desc) {
-            setHandle(tag, owner, name, desc, tag == Opcodes.H_INVOKEINTERFACE);
+            this.handle = new org.objectweb.asm.Handle(tag, owner, name, desc);
         }
 
     }


### PR DESCRIPTION
ctor Handle(tag, owner, name, desc, isInterface)
Doesn't exist on ASM 5.0.3