### PR TITLE
Make "conformVisibility" true by default

### DIFF
--- a/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
+++ b/src/main/java/org/spongepowered/asm/mixin/transformer/MixinConfig.java
@@ -114,7 +114,7 @@ final class MixinConfig implements Comparable<MixinConfig>, IMixinConfig {
     static class OverwriteOptions {
         
         @SerializedName("conformVisibility")
-        boolean conformAccessModifiers;
+        boolean conformAccessModifiers = true;
         
         @SerializedName("requireAnnotations")
         boolean requireOverwriteAnnotations;


### PR DESCRIPTION
I can't really think of any cases where this setting should be false, but devs can still manually set it to false if they need it to be for some reason. Having it true by default would automatically fix certain conflicts between access transformers and discontinued mixin mods, and would also alleviate that sort of issue for new mixin developers who might not know about the "conformVisibility" setting.